### PR TITLE
Stabilize HAT normalization for extreme logits

### DIFF
--- a/last/weight_fns.py
+++ b/last/weight_fns.py
@@ -110,9 +110,9 @@ def hat_normalize(blank: jnp.ndarray,
   Returns:
     Normalized (blank, lexical) weights.
   """
-  # Outside normalizer.
-  z = jnp.log(1 + jnp.exp(blank))
-  normalized_blank = blank - z
+  # Stable log-probabilities avoid overflow and cancellation for large logits.
+  z = nn.softplus(blank)
+  normalized_blank = nn.log_sigmoid(blank)
   normalized_lexical = nn.log_softmax(lexical) - z[..., jnp.newaxis]
   return normalized_blank, normalized_lexical
 

--- a/tests/weight_fns_test.py
+++ b/tests/weight_fns_test.py
@@ -15,15 +15,17 @@
 """Tests for weight_fns."""
 
 from absl.testing import absltest
+from absl.testing import parameterized
 import flax
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from last import weight_fns
+import numpy as np
 import numpy.testing as npt
 
 
-class WeightFnTest(absltest.TestCase):
+class WeightFnTest(parameterized.TestCase):
 
   def test_hat_normalize(self):
     blank = jnp.array([2., 7.])
@@ -33,6 +35,70 @@ class WeightFnTest(absltest.TestCase):
     actual_blank, actual_lexical = weight_fns.hat_normalize(blank, lexical)
     npt.assert_allclose(actual_blank, expect_blank, rtol=1e-3, atol=1e-6)
     npt.assert_allclose(actual_lexical, expect_lexical, rtol=1e-6)
+
+  @parameterized.product(dtype=[jnp.float32, jnp.float16], compiled=[False, True])
+  def test_hat_normalize_extreme_logits(self, dtype, compiled):
+    blank = jnp.array([-100., -20., 0., 20., 100.], dtype=dtype)
+    lexical = jnp.broadcast_to(jnp.array([0., 1., -1.], dtype=dtype), (5, 3))
+    normalize = weight_fns.hat_normalize
+    if compiled:
+      normalize = jax.jit(normalize)
+    actual_blank, actual_lexical = normalize(blank, lexical)
+    b = np.asarray(blank, dtype=np.float64)
+    l = np.asarray(lexical, dtype=np.float64)
+    expected_blank = -np.logaddexp(0., -b)
+    expected_lexical = l - np.logaddexp.reduce(l, axis=-1, keepdims=True)
+    expected_lexical -= np.logaddexp(0., b)[..., None]
+    tolerance = 2e-3 if dtype == jnp.float16 else 1e-6
+    self.assertTrue(np.isfinite(actual_blank).all())
+    self.assertTrue(np.isfinite(actual_lexical).all())
+    self.assertEqual(actual_blank.dtype, blank.dtype)
+    self.assertEqual(actual_lexical.dtype, lexical.dtype)
+    npt.assert_allclose(
+        actual_blank, expected_blank, rtol=tolerance, atol=tolerance)
+    npt.assert_allclose(
+        actual_lexical, expected_lexical, rtol=tolerance, atol=tolerance)
+    npt.assert_allclose(
+        np.exp(np.asarray(actual_blank, dtype=np.float64))
+        + np.exp(np.asarray(actual_lexical, dtype=np.float64)).sum(axis=-1),
+        np.ones(5), rtol=tolerance, atol=tolerance)
+
+  @parameterized.product(dtype=[jnp.float32, jnp.float16], compiled=[False, True])
+  def test_hat_normalize_extreme_gradients(self, dtype, compiled):
+    blank = jnp.array([-100., -20., 0., 20., 100.], dtype=dtype)
+    lexical = jnp.broadcast_to(jnp.array([0., 1., -1.], dtype=dtype), (5, 3))
+
+    def objective(b, l):
+      normalized_blank, normalized_lexical = weight_fns.hat_normalize(b, l)
+      return normalized_blank.sum() + normalized_lexical.sum()
+
+    grad_fn = jax.grad(objective, argnums=(0, 1))
+    if compiled:
+      grad_fn = jax.jit(grad_fn)
+    blank_grad, lexical_grad = grad_fn(blank, lexical)
+    b = np.asarray(blank, dtype=np.float64)
+    l = np.asarray(lexical, dtype=np.float64)
+    expected_blank = 1 / (1 + np.exp(b)) - 3 / (1 + np.exp(-b))
+    expected_lexical = 1 - 3 * np.exp(l) / np.exp(l).sum(
+        axis=-1, keepdims=True)
+    tolerance = 2e-3 if dtype == jnp.float16 else 1e-6
+    npt.assert_allclose(
+        blank_grad, expected_blank, rtol=tolerance, atol=tolerance)
+    npt.assert_allclose(
+        lexical_grad, expected_lexical, rtol=tolerance, atol=tolerance)
+
+  @parameterized.parameters(False, True)
+  def test_hat_normalize_preserves_small_blank_log_probability(self, compiled):
+    def blank_log_probability(blank):
+      return weight_fns.hat_normalize(blank, jnp.zeros(3))[0]
+
+    evaluate = jax.value_and_grad(blank_log_probability)
+    if compiled:
+      evaluate = jax.jit(evaluate)
+    value, grad = evaluate(jnp.array(20., dtype=jnp.float32))
+    npt.assert_allclose(
+        value, -np.logaddexp(0., -20.), rtol=1e-6, atol=0.)
+    npt.assert_allclose(grad, 1 / (1 + np.exp(20.)), rtol=1e-6, atol=0.)
 
   def test_log_softmax_normalize(self):
     blank = jnp.array([2., 7.])


### PR DESCRIPTION
`hat_normalize` overflows for large positive blank logits, producing zero total probability and NaN gradients. Subtracting the normalizer also loses small blank log-probabilities.

Use `softplus` and `log_sigmoid` for stable normalization. Add float16/float32 coverage for values, normalization and gradients in eager and JIT execution.

Validation: `python -m pytest -q tests` passes all 98 tests and 68 subtests. Ten new regression cases fail on unchanged upstream. Syntax checks and `git diff --check` pass.
